### PR TITLE
Add support for toSmiles bond-orders

### DIFF
--- a/Grouper/binding.cpp
+++ b/Grouper/binding.cpp
@@ -64,7 +64,7 @@ PYBIND11_MODULE(_Grouper, m) {
         .def("add_edge", &GroupGraph::addEdge,
             py::arg("src") = std::tuple<GroupGraph::NodeIDType, GroupGraph::PortType>{0, 0},
             py::arg("dst") = std::tuple<GroupGraph::NodeIDType, GroupGraph::PortType>{0, 0},
-            py::arg("order") = 1,
+            py::arg("order") = 1.,
             py::arg("strict") = true
         )
         .def("n_free_ports", &GroupGraph::numFreePorts)
@@ -124,7 +124,7 @@ PYBIND11_MODULE(_Grouper, m) {
         .def("add_edge", &AtomGraph::addEdge,
             py::arg("src"),
             py::arg("dst"),
-            py::arg("order") = 1,
+            py::arg("order") = 1.,
             py::arg("validate") = true)
         .def("from_smiles", &AtomGraph::fromSmiles)
         .def("from_smarts", &AtomGraph::fromSmarts)

--- a/Grouper/dataStructures.cpp
+++ b/Grouper/dataStructures.cpp
@@ -119,8 +119,7 @@ void createAtomGraphFromRDKit(const std::unique_ptr<RDKit::ROMol>& mol, AtomGrap
     for (size_t i=0; i<mol->getNumBonds(); i++) {
         const auto& bond = mol->getBondWithIdx(i);
         double border = bond->getBondTypeAsDouble();
-        int borderInt = (int)border;
-        aG.addEdge(bond->getBeginAtomIdx(), bond->getEndAtomIdx(), borderInt, validate);
+        aG.addEdge(bond->getBeginAtomIdx(), bond->getEndAtomIdx(), border, validate);
     }
 }
 
@@ -200,7 +199,8 @@ void validateAtomisticAtomGraph (const AtomGraph atomGraph, const std::vector<in
         throw GrouperParseException("Invalid "+ patternType +": " + pattern + " provided");
     }
     // Validate connected molecules
-    std::vector<boost::shared_ptr<RDKit::ROMol>> moleculesVector = RDKit::MolOps::getMolFrags(*mol);
+    std::vector<std::vector<int>> moleculesVector;
+    RDKit::MolOps::getMolFrags(*mol, moleculesVector);
     if (moleculesVector.size()>1) {
         throw GrouperParseException("Invalid "+ patternType +": " + pattern + " with detached molecules.");
     }
@@ -560,7 +560,7 @@ void GroupGraph::addNode(Group group) {
     nodetypes[group.ntype] = group.hubs;
 }
 
-bool GroupGraph::addEdge(std::tuple<NodeIDType,PortType> fromNodePort, std::tuple<NodeIDType,PortType>toNodePort, unsigned int bondOrder, bool strict) {
+bool GroupGraph::addEdge(std::tuple<NodeIDType,PortType> fromNodePort, std::tuple<NodeIDType,PortType>toNodePort, double bondOrder, bool strict) {
     NodeIDType from = std::get<0>(fromNodePort);
     PortType fromPort = std::get<1>(fromNodePort);
     NodeIDType to = std::get<0>(toNodePort);
@@ -598,7 +598,7 @@ bool GroupGraph::addEdge(std::tuple<NodeIDType,PortType> fromNodePort, std::tupl
         return false;
     }
 
-    const std::tuple<NodeIDType, PortType, NodeIDType, PortType, unsigned int> edge = std::make_tuple(from, fromPort, to, toPort, bondOrder);
+    const std::tuple<NodeIDType, PortType, NodeIDType, PortType, double> edge = std::make_tuple(from, fromPort, to, toPort, bondOrder);
     if (edges.count(edge) != 0) {
         if (strict) {
             throw std::invalid_argument("Edge already exists");
@@ -914,15 +914,20 @@ std::string GroupGraph::toSmiles() const {
     }
 
     // === Step 4: Add inter-subgraph (edge) bonds ===
-    for (const auto& [from, fromPort, to, toPort, bondOrder] : edges) {
+    std::unordered_map<double, RDKit::Bond::BondType> bondOrderMap;
+    bondOrderMap[1.0] = RDKit::Bond::BondType::SINGLE;
+    bondOrderMap[2.0] = RDKit::Bond::BondType::DOUBLE;
+    bondOrderMap[3.0] = RDKit::Bond::BondType::TRIPLE;
+    bondOrderMap[1.5] = RDKit::Bond::BondType::AROMATIC;
+    for (const auto &[from, fromPort, to, toPort, bondOrder] : edges)
+    {
         int fromAtom = nodePortToAtomIndex.at(from).at(fromPort);
         int toAtom   = nodePortToAtomIndex.at(to).at(toPort);
-
-        molecularGraph->addBond(fromAtom, toAtom, static_cast<RDKit::Bond::BondType>(bondOrder));
+        molecularGraph->addBond(fromAtom, toAtom, bondOrderMap[bondOrder]);
     }
 
     // === Step 5: Convert to SMILES and return ===
-    return RDKit::MolToSmiles(*molecularGraph, true);
+    return RDKit::MolToSmiles(*molecularGraph, true, false, -1, true, false);
 }
 
 
@@ -1020,7 +1025,7 @@ std::unique_ptr<AtomGraph> GroupGraph::toAtomicGraph() const {
             int atomIdx1 = nodeSubGraphIndicesToMolecularGraphIndices[std::to_string(nodeID)][(*bond)->getBeginAtomIdx()];
             int atomIdx2 = nodeSubGraphIndicesToMolecularGraphIndices[std::to_string(nodeID)][(*bond)->getEndAtomIdx()];
             // molecularGraph->addBond(atomIdx1, atomIdx2, newBond.getBondType());
-            unsigned int bondOrder = (*bond)->getBondTypeAsDouble();
+            double bondOrder = (*bond)->getBondTypeAsDouble();
             atomGraph->addEdge(atomIdx1, atomIdx2, bondOrder);
         }
     }
@@ -1033,7 +1038,7 @@ std::unique_ptr<AtomGraph> GroupGraph::toAtomicGraph() const {
         PortType toPort = std::get<3>(edge);
         NodeIDType fromAtom = nodePortToAtomIndex[std::to_string(from)][fromPort];
         NodeIDType toAtom = nodePortToAtomIndex[std::to_string(to)][toPort];
-        unsigned int bondOrder = std::get<4>(edge);
+        double bondOrder = std::get<4>(edge);
         atomGraph->addEdge(fromAtom, toAtom, bondOrder);
     }
 
@@ -1167,7 +1172,7 @@ void GroupGraph::deserialize(const std::string& data) {
 void GroupGraph::toNautyGraph(int* n, int* m, graph** adj) const {
     std::unordered_map<NodeIDType, int> group_to_nauty;
     std::unordered_map<std::pair<NodeIDType, PortType>, int> port_to_nauty;
-    std::unordered_map<std::tuple<NodeIDType, PortType, NodeIDType, PortType, unsigned int>, int> edge_to_nauty;
+    std::unordered_map<std::tuple<NodeIDType, PortType, NodeIDType, PortType, double>, int> edge_to_nauty;
 
     int nodeIndex = 0;
 
@@ -1356,7 +1361,7 @@ void AtomGraph::addNode(Atom atom) {
     nodes[id] = atom;
 }
 
-void AtomGraph::addEdge(NodeIDType src, NodeIDType dst, unsigned int order, bool validate) {
+void AtomGraph::addEdge(NodeIDType src, NodeIDType dst, double order, bool validate) {
     if (nodes.find(src) == nodes.end() || nodes.find(dst) == nodes.end())
     {
         if (nodes.find(src) == nodes.end()) {
@@ -1567,7 +1572,7 @@ void AtomGraph::fromSmarts(const std::string& smarts) {
     int prevDepth = 0;
     int currentDepth = 0;
     NodeIDType currentNode = 0;
-    int bondOrder = 1;
+    double bondOrder = 1;
 
     for (size_t i = 0; i < smarts.length(); ++i) {
         char c = smarts[i];
@@ -1739,7 +1744,7 @@ void AtomGraph::fromSmiles(const std::string& smiles) {
     std::stack<NodeIDType> nodeStack; // Stack to handle branching
     std::unordered_map<int, NodeIDType> ringClosures; // Map for ring closure indices
     NodeIDType lastNode = -1;
-    int bondOrder = 1; // Default to single bond
+    double bondOrder = 1; // Default to single bond
 
     for (size_t i = 0; i < smiles.size(); ++i) {
         char c = smiles[i];
@@ -1888,7 +1893,7 @@ std::string AtomGraph::printGraph() const {
         output << "    Atom " << entry.first << " (" << entry.second.ntype << ")" << " Valency: " << entry.second.valency << "\n";
     }
     output << "Edges (without duplication):\n";
-    std::unordered_set<std::tuple<NodeIDType, NodeIDType, unsigned int>> uniqueEdges;
+    std::unordered_set<std::tuple<NodeIDType, NodeIDType, double>> uniqueEdges;
     for (const auto& [src, dst, order] : edges) {
         if (uniqueEdges.find(std::make_tuple(src, dst, order)) == uniqueEdges.end()) {
             output << "    Edge: " << src << " <-> " << dst <<" Order: (" <<order<<")"<<"\n";
@@ -2128,3 +2133,4 @@ std::vector<AtomGraph::NodeIDType> AtomGraph::nodeOrbits() const {
 
     return orbits;
 }
+

--- a/Grouper/dataStructures.hpp
+++ b/Grouper/dataStructures.hpp
@@ -30,25 +30,25 @@ namespace std {
     }
 
     template <>
-    struct hash<std::tuple<int, int, unsigned int>> {
-        std::size_t operator()(const std::tuple<int, int, unsigned int>& t) const {
+    struct hash<std::tuple<int, int, double>> {
+        std::size_t operator()(const std::tuple<int, int, double>& t) const {
             std::size_t seed = 0;
             hash_combine(seed, std::hash<int>{}(std::get<0>(t)));
             hash_combine(seed, std::hash<int>{}(std::get<1>(t)));
-            hash_combine(seed, std::hash<unsigned int>{}(std::get<2>(t)));
+            hash_combine(seed, std::hash<double>{}(std::get<2>(t)));
             return seed;
         }
     };
 
     template <>
-    struct hash<std::tuple<int, int, int, int, unsigned int>> {
-        std::size_t operator()(const std::tuple<int, int, int, int, unsigned int>& t) const {
+    struct hash<std::tuple<int, int, int, int, double>> {
+        std::size_t operator()(const std::tuple<int, int, int, int, double>& t) const {
             std::size_t seed = 0;
             hash_combine(seed, std::hash<int>{}(std::get<0>(t)));
             hash_combine(seed, std::hash<int>{}(std::get<1>(t)));
             hash_combine(seed, std::hash<int>{}(std::get<2>(t)));
             hash_combine(seed, std::hash<int>{}(std::get<3>(t)));
-            hash_combine(seed, std::hash<unsigned int>{}(std::get<4>(t)));
+            hash_combine(seed, std::hash<double>{}(std::get<4>(t)));
             return seed;
         }
     };
@@ -96,7 +96,7 @@ public:
     };
 
     std::unordered_map<NodeIDType, Atom> nodes; ///< Map of node IDs to their respective nodes.
-    std::unordered_set<std::tuple<NodeIDType, NodeIDType, unsigned int>> edges; ///< Map of node IDs to their respective neighbors. (srcNodeID, dstNodeID, bondOrder)
+    std::unordered_set<std::tuple<NodeIDType, NodeIDType, double>> edges; ///< Map of node IDs to their respective neighbors. (srcNodeID, dstNodeID, bondOrder)
 
     AtomGraph();
     AtomGraph(const AtomGraph& other);
@@ -105,7 +105,7 @@ public:
 
     void addNode(const std::string& ntype = "", int valency = -1);
     void addNode(Atom atom);
-    void addEdge(NodeIDType src, NodeIDType dst, unsigned int order = 1, bool validate=true);
+    void addEdge(NodeIDType src, NodeIDType dst, double order = 1, bool validate=true);
     int getFreeValency(NodeIDType nid) const;
     std::string printGraph() const;
     std::vector<std::vector<NodeIDType>> nodeAut() const;
@@ -146,7 +146,7 @@ public:
 
     // Attributes
     std::unordered_map<NodeIDType, Group> nodes; ///< Map of node IDs to their respective nodes.
-    std::unordered_set<std::tuple<NodeIDType, PortType, NodeIDType, PortType, unsigned int>> edges; ///< List of edges connecting nodes. (srcNodeID, srcPort, dstNodeID, dstPort, bondOrder)
+    std::unordered_set<std::tuple<NodeIDType, PortType, NodeIDType, PortType, double>> edges; ///< List of edges connecting nodes. (srcNodeID, srcPort, dstNodeID, dstPort, bondOrder)
     std::unordered_map<std::string, std::vector<PortType>> nodetypes; ///< Map of node types to their respective ports.
     bool isCoarseGrained = false;
     std::unordered_set<std::pair<NodeIDType, PortType>> used_ports; // Fast lookup for used ports
@@ -168,7 +168,7 @@ public:
     bool addEdge(
         std::tuple<NodeIDType, PortType> fromNodePort,
         std::tuple<NodeIDType, PortType> toNodePort,
-        unsigned int bondOrder = 1,
+        double bondOrder = 1,
         bool verbose = false
     );
     int numFreePorts(NodeIDType nid) const;
@@ -255,7 +255,7 @@ namespace std {
             }
             for (const auto& edge : graph.edges) {
                 h ^= std::hash<std::tuple<GroupGraph::NodeIDType, GroupGraph::PortType,
-                                        GroupGraph::NodeIDType, GroupGraph::PortType, unsigned int>>{}(edge)
+                                        GroupGraph::NodeIDType, GroupGraph::PortType, double>>{}(edge)
                     + 0x9e3779b9 + (h << 6) + (h >> 2);
             }
             return h;
@@ -285,7 +285,7 @@ namespace std {
             //     }
             // }
             for(const auto& [src, dst, order] : graph.edges) {
-                h ^= std::hash<std::tuple<AtomGraph::NodeIDType, AtomGraph::NodeIDType, unsigned int>>{}(std::make_tuple(src, dst, order)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+                h ^= std::hash<std::tuple<AtomGraph::NodeIDType, AtomGraph::NodeIDType, double>>{}(std::make_tuple(src, dst, order)) + 0x9e3779b9 + (h << 6) + (h >> 2);
             }
 
             return h;

--- a/Grouper/fragmentation.py
+++ b/Grouper/fragmentation.py
@@ -237,9 +237,7 @@ def _get_group_bonds(mol, group, latest_group_indices):
                 latest_group_indices[:-1], bondedAtomIndex
             )  # latest_group_indices[:-1] because we don't want to count group, which is already added to latest_group_indices
             if bonded_groupIndex != -1:
-                bond_order = int(
-                    bond.GetBondTypeAsDouble()
-                )  # NOTE: Since we have ints, aromatic 1.5 bonds are treated as single bonds
+                bond_order = bond.GetBondTypeAsDouble()
                 bonds.append(
                     (
                         (newest_groupIndex, i),

--- a/Grouper/tests/test_data_structures.py
+++ b/Grouper/tests/test_data_structures.py
@@ -193,6 +193,21 @@ class TestGroupGraph(BaseTest):
         graph.add_edge((2, 1), (1, 1))
         assert (2, 1, 1, 1, 1) in graph.edges
 
+    def test_add_edge_bond_order(self):
+        graph = GroupGraph()
+        graph.add_node("type1", "C", [0, 0, 0, 0])
+        graph.add_node("type2", "C", [0, 0, 0, 0])
+        graph.add_node("type3", "C", [0, 0, 0, 0])
+
+        graph.add_edge((0, 0), (1, 0), 2)
+        assert (0, 0, 1, 0, 2) in graph.edges
+
+        graph.add_edge((2, 1), (1, 1), 1.5)
+        assert (2, 1, 1, 1, 1.5) in graph.edges
+
+        graph.add_edge((2, 2), (1, 2), 1)
+        assert (2, 2, 1, 2, 1) in graph.edges
+
     def test_add_edge_with_invalid_nodes(self):
         graph = GroupGraph()
         graph.add_node("node1", "C", [0, 0])

--- a/Grouper/tests/test_interchangeable.py
+++ b/Grouper/tests/test_interchangeable.py
@@ -165,3 +165,11 @@ class TestConversion(BaseTest):
             for gg in all_gGs:
                 s = gg.to_smiles()
                 assert smiles == s
+                
+    def test_aromatic_smiles(self):
+        smiles = "c1ccccc1"
+        node_defs = set()
+        node_defs.add(Group('ringC', '[cX3]', [0,0,0], "SMARTS"))
+        node_defs.add(Group('COOH', '[CX3](=[OX1])[O;H1]', [0], "SMARTS"))
+        gg = fragment(smiles, node_defs)[0]
+        assert gg.to_smiles() == smiles


### PR DESCRIPTION
See the added tests for new handling using bond order to write out correct smiles for aromatic molecules.