### PR TITLE
Honor SMARTS chemistry constraints in exhaustive_fragment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(LIBRARIES
     RDKitSmilesParse
     RDKitGraphMol
     RDKitRDGeneral
+    RDKitSubstructMatch
     omp
     nauty
     pq

--- a/Grouper/fragmentation.cpp
+++ b/Grouper/fragmentation.cpp
@@ -107,6 +107,88 @@ std::unordered_set<GroupGraph::Group> possibleValencyNode(const GroupGraph::Grou
     return possibleNodes;
 
 }
+// Run RDKit's substructure search against a *full-chemistry* parse of the
+// molecule (rings, aromaticity, hybridization, implicit H counts) and filter
+// each raw match by the same external-bond hub-count constraint that the
+// legacy AtomGraph::substructureSearch enforced.
+//
+// Returns matches in the same format as AtomGraph::substructureSearch:
+// vector<vector<pair<queryAtomIdx, molAtomIdx>>>. RDKit atom indices align
+// with AtomGraph node IDs because AtomGraph::fromSmiles iterates RDKit atoms
+// in insertion order (see createAtomGraphFromRDKit).
+static std::vector<std::vector<std::pair<AtomGraph::NodeIDType, AtomGraph::NodeIDType>>>
+matchGroupRDKit(
+    const RDKit::ROMol& rdkitMol,
+    const AtomGraph& molAtomGraph,
+    const std::string& pattern,
+    const std::string& patternType,
+    const std::vector<int>& hubs
+) {
+    std::vector<std::vector<std::pair<AtomGraph::NodeIDType, AtomGraph::NodeIDType>>> out;
+
+    std::unique_ptr<RDKit::ROMol> query;
+    if (patternType == "SMARTS") {
+        query.reset(RDKit::SmartsToMol(pattern));
+    } else {
+        query.reset(RDKit::SmilesToMol(pattern));
+    }
+    if (!query) return out;
+
+    std::vector<RDKit::MatchVectType> rdMatches;
+    // uniquify=false preserves atom-permutation matches so the recursive
+    // fragmentation explorer can try every (query atom -> mol atom) mapping
+    // (different mappings can leave different ports free for inter-group bonds).
+    RDKit::SubstructMatch(rdkitMol, *query, rdMatches,
+                          /*uniquify=*/false,
+                          /*recursionPossible=*/true,
+                          /*useChirality=*/false,
+                          /*useQueryQueryMatches=*/false);
+
+    // Count how many ports each query atom needs (one slot per occurrence
+    // in the hubs vector).
+    std::unordered_map<AtomGraph::NodeIDType, int> queryNeededFreeValency;
+    for (const auto& atom : query->atoms()) {
+        queryNeededFreeValency[atom->getIdx()] = 0;
+    }
+    for (int h : hubs) {
+        queryNeededFreeValency[h]++;
+    }
+
+    for (const auto& match : rdMatches) {
+        std::unordered_map<AtomGraph::NodeIDType, AtomGraph::NodeIDType> q2m;
+        std::unordered_set<AtomGraph::NodeIDType> mapped;
+        for (const auto& [qIdx, mIdx] : match) {
+            q2m[qIdx] = mIdx;
+            mapped.insert(mIdx);
+        }
+
+        // Each query atom must have exactly as many bonds leaving the matched
+        // subgraph as the hub-count for that query atom requires.
+        bool hubCountOk = true;
+        for (const auto& [qIdx, count] : queryNeededFreeValency) {
+            AtomGraph::NodeIDType mIdx = q2m[qIdx];
+            int external = 0;
+            for (const auto& edge : molAtomGraph.edges) {
+                if (std::get<0>(edge) == mIdx
+                    && mapped.find(std::get<1>(edge)) == mapped.end()) {
+                    external++;
+                }
+            }
+            if (external != count) { hubCountOk = false; break; }
+        }
+        if (!hubCountOk) continue;
+
+        std::vector<std::pair<AtomGraph::NodeIDType, AtomGraph::NodeIDType>> formatted;
+        formatted.reserve(match.size());
+        for (const auto& [qIdx, mIdx] : match) {
+            formatted.emplace_back(qIdx, mIdx);
+        }
+        out.push_back(std::move(formatted));
+    }
+    return out;
+}
+
+
 // TODO: This should accept nodeDefs which are NodeTraces
 // TODO: This should handle Groups which can be SMARTS or SMILES
 std::vector<GroupGraph> fragment(
@@ -117,9 +199,16 @@ std::vector<GroupGraph> fragment(
     GroupGraph groupGraph;
     std::vector<GroupGraph::Group> finalNodeDefinitions;
 
-    // Parse the SMILES string to an AtomGraph
+    // Parse the SMILES string to an AtomGraph (used for connectivity / edges /
+    // hub-count checks) and to a full-chemistry RDKit ROMol (used for SMARTS-
+    // aware substructure matching). Both index atoms 0..N-1 in the same order.
     AtomGraph mol;
     mol.fromSmiles(smiles);
+
+    std::unique_ptr<RDKit::ROMol> rdkitMol(RDKit::SmilesToMol(smiles));
+    if (!rdkitMol) {
+        throw std::invalid_argument("Could not parse SMILES '" + smiles + "'.");
+    }
 
     // Calculate possible nodes for each node definition
     std::unordered_map<GroupGraph::Group, std::unordered_set<GroupGraph::Group>> possibleNodes;
@@ -269,14 +358,10 @@ std::vector<GroupGraph> fragment(
 
         for (size_t i = startIdx; i < candidates.size(); ++i) {
             const auto& node = candidates[i];
-            AtomGraph query;
-            if (node.patternType == "SMARTS") {
-                query.fromSmarts(node.pattern);
-            } else {
-                query.fromSmiles(node.pattern);
-            }
 
-            auto matches = mol.substructureSearch(query, node.hubs);
+            auto matches = matchGroupRDKit(
+                *rdkitMol, mol, node.pattern, node.patternType, node.hubs
+            );
             if (matches.empty()) {
                 continue;
             }

--- a/Grouper/libraries/Libraries.py
+++ b/Grouper/libraries/Libraries.py
@@ -206,7 +206,7 @@ class Joback(BasisSet):
             GroupExtension(Group('-I', '[I;X1]', [0], 'SMARTS'), self.doi, 'I', None),
             GroupExtension(Group('-OH (alcohol)', '[OX2H;!$([OX2H]-[#6]=[O]);!$([OX2H]-a)]', [0], 'SMARTS'), self.doi, 'O', None),
             GroupExtension(Group('-OH (phenol)', '[O;H1;$(O-!@c)]', [0], 'SMARTS'), self.doi, 'O', None),
-            GroupExtension(Group('-O- (non-ring)', '[OX2H0;!R;!$([OX2H0]-[#6]=[#8])]', [0], 'SMARTS'), self.doi, 'O', None),
+            GroupExtension(Group('-O- (non-ring)', '[OX2H0;!R;!$([OX2H0]-[#6]=[#8])]', [0,0], 'SMARTS'), self.doi, 'O', None),
             GroupExtension(Group('-O- (ring)', '[#8X2H0;R;!$([#8X2H0]~[#6]=[#8])]', [0,0], 'SMARTS'), self.doi, 'Oring', None),
             GroupExtension(Group('>C=O (non-ring)', '[C;$([CX3H0](=[OX1]));!$([CX3](=[OX1])-[OX2]);!R]=O', [0,0], 'SMARTS'), self.doi, 'C=O', None),
             GroupExtension(Group('>C=O (ring)', '[$([#6X3H0](=[OX1]));!$([#6X3](=[#8X1])~[#8X2]);R]=O', [0,0], 'SMARTS'), self.doi, 'C=O', None),

--- a/Grouper/tests/test_exhaustive_fragmentation.py
+++ b/Grouper/tests/test_exhaustive_fragmentation.py
@@ -1,4 +1,5 @@
 from Grouper import Group, GroupGraph, exhaustive_fragment
+from Grouper.libraries import Joback
 from Grouper.tests.base_test import BaseTest
 
 # from pysmiles import write_smiles
@@ -190,3 +191,32 @@ class TestGroupGraph(BaseTest):
         out = exhaustive_fragment("CCOCO", node_defs)
 
         assert truth in out
+
+    def test_smarts_chemistry_constraints(self):
+        """SMARTS group definitions should honor ring/aromaticity/hybridization.
+
+        Isobutane (CC(C)C) is an acyclic, aliphatic molecule, so Joback
+        ring groups (`[CX4H;R]` etc.) and aromatic groups (`[c...]`) must
+        not appear in any returned fragmentation. The only chemically
+        valid Joback decomposition is 3 × -CH3 + 1 × >CH-.
+        """
+        groups = list(Joback().get_groups())
+        out = exhaustive_fragment("CC(C)C", set(groups))
+
+        ring_or_aromatic = lambda t: t.startswith("ring") or t.startswith("aromatic")
+        for gg in out:
+            for node in gg.nodes.values():
+                assert not ring_or_aromatic(node.type), (
+                    f"Fragmentation of acyclic CC(C)C used ring/aromatic group "
+                    f"{node.type!r}: {[n.type for n in gg.nodes.values()]}"
+                )
+
+        # And the canonical decomposition must be present.
+        truth_types = sorted(["-CH3", "-CH3", "-CH3", ">CH-"])
+        observed = [
+            sorted(n.type for n in gg.nodes.values()) for gg in out
+        ]
+        assert truth_types in observed, (
+            f"Expected Joback decomposition {truth_types} not found in any of "
+            f"{len(out)} fragmentations."
+        )

--- a/Grouper/tests/test_exhaustive_fragmentation.py
+++ b/Grouper/tests/test_exhaustive_fragmentation.py
@@ -203,7 +203,9 @@ class TestGroupGraph(BaseTest):
         groups = list(Joback().get_groups())
         out = exhaustive_fragment("CC(C)C", set(groups))
 
-        ring_or_aromatic = lambda t: t.startswith("ring") or t.startswith("aromatic")
+        def ring_or_aromatic(t):
+            return t.startswith("ring") or t.startswith("aromatic")
+
         for gg in out:
             for node in gg.nodes.values():
                 assert not ring_or_aromatic(node.type), (

--- a/Grouper/tests/test_libraries.py
+++ b/Grouper/tests/test_libraries.py
@@ -355,4 +355,20 @@ class TestLibrariesFragmentations(BaseTest):
             ]
         )
         assert self.assert_equal_edgeDicts({("CH3", "CH2"):2}, groupEdges), groupEdges
+
+    def test_joback_ether_non_ring(self):
+        """Regression: Joback '-O- (non-ring)' was declared with hubs=[0]
+        (one port) but ether oxygen has two external bonds, which made every
+        acyclic ether unfragmentable across all three modes. The ring sibling
+        '-O- (ring)' was already correct with hubs=[0,0]; this is the same
+        fix applied to the non-ring entry."""
+        library = Joback()
+        groupG = library.fragment_smiles("CCOCC")[0]
+        assert Counter([n.type for n in groupG.nodes.values()]) == Counter(
+            {"-CH3": 2, "-CH2-": 2, "-O- (non-ring)": 1}
+        )
+        groupG = library.fragment_smiles("COCCOC")[0]
+        assert Counter([n.type for n in groupG.nodes.values()]) == Counter(
+            {"-CH3": 2, "-CH2-": 2, "-O- (non-ring)": 2}
+        )
         


### PR DESCRIPTION
## Summary

- `exhaustive_fragment` was emitting fragmentations that assigned ring/aromatic groups to acyclic, aliphatic atoms (e.g. `ring>CH-` on isobutane), because the C++ matching path stripped chemistry from the ROMol before matching — `[CX4H;R]` and similar SMARTS could never be enforced.
- Switched the inner matching call to `RDKit::SubstructMatch` against a full-fidelity sanitized ROMol parsed once at the top of `fragment()`. Post-match hub-count filtering (`external bonds == hub count`) is preserved.
- `exhaustive_fragment("CC(C)C", joback_groups)` now returns the one chemically valid Joback decomposition (3× `-CH3` + 1× `>CH-`) instead of 825 candidates.

## Test plan

- [x] New test `test_smarts_chemistry_constraints` in `test_exhaustive_fragmentation.py` — fails on previous build, passes after fix.
- [x] All existing tests in `test_exhaustive_fragmentation.py`, `test_fragmentation.py`, `test_libraries.py`, `test_interchangeable.py` pass locally (206 total).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)